### PR TITLE
fix: 조회수 카운트, 답글 관련 삭제 로직 추가

### DIFF
--- a/src/main/kotlin/noul/oe/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/noul/oe/comment/repository/CommentRepository.kt
@@ -7,5 +7,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface CommentRepository : JpaRepository<Comment, Long> {
     fun findAllByPostId(postId: Long): List<Comment>
-    fun countByPostId(postId: Long): Long
+    fun findAllByParentId(parentId: Long): List<Comment>
+
+    fun countByPostId(postId: Long): Int
 }

--- a/src/main/kotlin/noul/oe/comment/service/CommentService.kt
+++ b/src/main/kotlin/noul/oe/comment/service/CommentService.kt
@@ -78,6 +78,9 @@ class CommentService(
             throw UnauthorizedCommentAccessException()
         }
 
+        // 댓글과 관련된 답글까지 같이 삭제
+        val replies = commentRepository.findAllByParentId(commentId)
+        commentRepository.deleteAll(replies)
         commentRepository.delete(comment)
     }
 

--- a/src/main/kotlin/noul/oe/post/dto/response/PostDetailResponse.kt
+++ b/src/main/kotlin/noul/oe/post/dto/response/PostDetailResponse.kt
@@ -13,12 +13,12 @@ data class PostDetailResponse(
     val content: String,
     val viewCount: Long,
     var likeCount: Long,
-    val commentCount: Long,
+    val commentCount: Int,
     val liked: Boolean,
     val createdAt: LocalDateTime,
 ) {
     companion object {
-        fun from(post: Post, user: User, likeCount: Long, commentCount: Long, liked: Boolean): PostDetailResponse = PostDetailResponse(
+        fun from(post: Post, user: User, likeCount: Long, commentCount: Int, liked: Boolean): PostDetailResponse = PostDetailResponse(
             postId = post.id,
             userId = post.userId,
             username = user.username,

--- a/src/main/kotlin/noul/oe/post/service/PostService.kt
+++ b/src/main/kotlin/noul/oe/post/service/PostService.kt
@@ -33,6 +33,7 @@ class PostService(
         postRepository.save(post)
     }
 
+    @Transactional
     fun read(postId: Long, userId: String): PostDetailResponse {
         val post = postRepository.findById(postId).orElseThrow { PostNotFoundException() }
         post.increaseViewCount()
@@ -48,7 +49,7 @@ class PostService(
     fun readAll(pageable: Pageable): Page<PostPageResponse> {
         return postRepository.findAll(pageable).map { post ->
             val username = fetchUsernameByUserId(post.userId)
-            val commentCount = 0
+            val commentCount = commentRepository.countByPostId(post.id)
             PostPageResponse.from(post, username, commentCount)
         }
     }

--- a/src/test/kotlin/noul/oe/post/controller/PostControllerTest.kt
+++ b/src/test/kotlin/noul/oe/post/controller/PostControllerTest.kt
@@ -76,9 +76,10 @@ class PostControllerTest {
             content = "content",
             viewCount = 10L,
             likeCount = 2L,
-            commentCount = 5L,
+            commentCount = 5,
             liked = true,
-            createdAt = LocalDateTime.now()
+            createdAt = LocalDateTime.now(),
+            editable = true
         )
         whenever(postService.read(postId, userId)).thenReturn(response)
         whenever(userService.getUserIdByUsername(username)).thenReturn(userId)


### PR DESCRIPTION
1. 게시글 read 시, 조회 수 카운트 로직 추가
2. 댓글 삭제 시, parentId 관련 답글 같이 삭제 로직 추가