### PR TITLE
refactor: [#25] Arch 테스트 추가 및 InfoProvider 도입으로 도메인 모듈 간 의존성 제거

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	testRuntimeOnly("com.h2database:h2")
+	testImplementation("com.tngtech.archunit:archunit-junit5:1.4.1")
 }
 
 kotlin {

--- a/src/main/kotlin/noul/oe/domain/comment/controller/CommentApiController.kt
+++ b/src/main/kotlin/noul/oe/domain/comment/controller/CommentApiController.kt
@@ -5,18 +5,14 @@ import noul.oe.domain.comment.dto.request.CommentCreateRequest
 import noul.oe.domain.comment.dto.request.CommentModifyRequest
 import noul.oe.domain.comment.dto.response.CommentResponse
 import noul.oe.domain.comment.service.CommentService
-import noul.oe.domain.user.service.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api")
 class CommentApiController(
     private val commentService: CommentService,
-    private val userService: UserService,
 ) {
     /**
      * 댓글 생성

--- a/src/main/kotlin/noul/oe/domain/comment/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/noul/oe/domain/comment/dto/response/CommentResponse.kt
@@ -1,7 +1,6 @@
 package noul.oe.domain.comment.dto.response
 
 import noul.oe.domain.comment.entity.Comment
-import noul.oe.domain.user.entity.User
 import java.time.LocalDateTime
 
 data class CommentResponse(
@@ -26,12 +25,17 @@ data class CommentResponse(
             )
         }
 
-        fun from(comment: Comment, user: User, currentUserId: String, children: List<CommentResponse> = emptyList()): CommentResponse {
+        fun from(
+            comment: Comment,
+            username: String,
+            currentUserId: String,
+            children: List<CommentResponse> = emptyList()
+        ): CommentResponse {
             return CommentResponse(
                 id = comment.id,
                 content = comment.content,
                 userId = comment.userId,
-                username = user.username,
+                username = username,
                 editable = comment.userId == currentUserId,
                 createdAt = comment.createdAt,
                 children = children,

--- a/src/main/kotlin/noul/oe/domain/comment/infra/CommentInfoProviderImpl.kt
+++ b/src/main/kotlin/noul/oe/domain/comment/infra/CommentInfoProviderImpl.kt
@@ -1,0 +1,29 @@
+package noul.oe.domain.comment.infra
+
+import noul.oe.domain.comment.repository.CommentRepository
+import noul.oe.support.info.CommentInfoProvider
+import noul.oe.support.info.dto.CommentInfo
+import org.springframework.stereotype.Component
+
+@Component
+class CommentInfoProviderImpl(
+    private val commentRepository: CommentRepository,
+) : CommentInfoProvider {
+
+    override fun getCommentCount(postId: Long): Int {
+        return commentRepository.countByPostId(postId)
+    }
+
+    override fun getCommentList(postId: Long, userId: String): List<CommentInfo> {
+        return commentRepository.findAllByPostId(postId)
+            .map {
+                CommentInfo(
+                    id = it.id,
+                    content = it.content,
+                    userId = it.userId,
+                    createdAt = it.createdAt.toString(),
+                    editable = it.userId == userId,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/noul/oe/domain/post/controller/PostPageController.kt
+++ b/src/main/kotlin/noul/oe/domain/post/controller/PostPageController.kt
@@ -1,6 +1,5 @@
 package noul.oe.domain.post.controller
 
-import noul.oe.domain.comment.service.CommentService
 import noul.oe.domain.post.exception.PostPermissionDeniedException
 import noul.oe.domain.post.service.PostService
 import noul.oe.support.security.SecurityUtils
@@ -16,7 +15,6 @@ import java.security.Principal
 @Controller
 class PostPageController(
     private val postService: PostService,
-    private val commentService: CommentService,
 ) {
     /**
      * 게시글 목록 조회(페이징)
@@ -40,10 +38,9 @@ class PostPageController(
     @GetMapping("/posts/{postId}")
     fun readDetail(@PathVariable postId: Long, model: Model): String {
         val user = SecurityUtils.getCurrentUser()
-        val post = postService.read(postId, user)
-        val comments = commentService.readAll(postId, user.userId)
-        model.addAttribute("post", post)
-        model.addAttribute("comments", comments)
+        val postWithComments = postService.readWithComments(postId, user)
+        model.addAttribute("post", postWithComments.post)
+        model.addAttribute("comments", postWithComments.comments)
         model.addAttribute("username", user.username)
 
         return "post-detail"

--- a/src/main/kotlin/noul/oe/domain/post/dto/response/PostDetailResponse.kt
+++ b/src/main/kotlin/noul/oe/domain/post/dto/response/PostDetailResponse.kt
@@ -1,7 +1,6 @@
 package noul.oe.domain.post.dto.response
 
 import noul.oe.domain.post.entity.Post
-import noul.oe.domain.user.entity.User
 import java.time.LocalDateTime
 
 data class PostDetailResponse(

--- a/src/main/kotlin/noul/oe/domain/post/dto/response/PostDetailWithCommentsResponse.kt
+++ b/src/main/kotlin/noul/oe/domain/post/dto/response/PostDetailWithCommentsResponse.kt
@@ -1,0 +1,8 @@
+package noul.oe.domain.post.dto.response
+
+import noul.oe.support.info.dto.CommentInfo
+
+data class PostDetailWithCommentsResponse(
+    val post: PostDetailResponse,
+    val comments: List<CommentInfo>
+)

--- a/src/main/kotlin/noul/oe/domain/user/infra/UserDetailsLoaderImpl.kt
+++ b/src/main/kotlin/noul/oe/domain/user/infra/UserDetailsLoaderImpl.kt
@@ -1,4 +1,4 @@
-package noul.oe.domain.user.service
+package noul.oe.domain.user.infra
 
 import noul.oe.domain.user.repository.UserRepository
 import noul.oe.support.security.UserDetailsLoader
@@ -6,9 +6,9 @@ import noul.oe.support.security.UserPrincipal
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
-import org.springframework.stereotype.Service
+import org.springframework.stereotype.Component
 
-@Service
+@Component
 class UserDetailsLoaderImpl(
     private val userRepository: UserRepository
 ) : UserDetailsLoader, UserDetailsService {

--- a/src/main/kotlin/noul/oe/domain/user/infra/UserInfoProviderImpl.kt
+++ b/src/main/kotlin/noul/oe/domain/user/infra/UserInfoProviderImpl.kt
@@ -1,0 +1,18 @@
+package noul.oe.domain.user.infra
+
+import noul.oe.domain.user.exception.UserNotFoundException
+import noul.oe.domain.user.repository.UserRepository
+import noul.oe.support.info.UserInfoProvider
+import org.springframework.stereotype.Component
+
+@Component
+class UserInfoProviderImpl(
+    private val userRepository: UserRepository
+) : UserInfoProvider {
+
+    override fun getUsername(userId: String): String {
+        return userRepository.findById(userId)
+            .orElseThrow { UserNotFoundException("User not found: userId=$userId") }
+            .username
+    }
+}

--- a/src/main/kotlin/noul/oe/support/info/CommentInfoProvider.kt
+++ b/src/main/kotlin/noul/oe/support/info/CommentInfoProvider.kt
@@ -1,0 +1,8 @@
+package noul.oe.support.info
+
+import noul.oe.support.info.dto.CommentInfo
+
+interface CommentInfoProvider {
+    fun getCommentCount(postId: Long): Int
+    fun getCommentList(postId: Long, userId: String): List<CommentInfo>
+}

--- a/src/main/kotlin/noul/oe/support/info/PostInfoProvider.kt
+++ b/src/main/kotlin/noul/oe/support/info/PostInfoProvider.kt
@@ -1,0 +1,4 @@
+package noul.oe.support.info
+
+interface PostInfoProvider {
+}

--- a/src/main/kotlin/noul/oe/support/info/UserInfoProvider.kt
+++ b/src/main/kotlin/noul/oe/support/info/UserInfoProvider.kt
@@ -1,0 +1,5 @@
+package noul.oe.support.info
+
+interface UserInfoProvider {
+    fun getUsername(userId: String): String
+}

--- a/src/main/kotlin/noul/oe/support/info/dto/CommentInfo.kt
+++ b/src/main/kotlin/noul/oe/support/info/dto/CommentInfo.kt
@@ -1,0 +1,10 @@
+package noul.oe.support.info.dto
+
+data class CommentInfo(
+    val id: Long,
+    val content: String,
+    val userId: String,
+    val username: String = "",
+    val createdAt: String,
+    val editable: Boolean,
+)

--- a/src/test/kotlin/noul/oe/arch/ArchTest.kt
+++ b/src/test/kotlin/noul/oe/arch/ArchTest.kt
@@ -1,0 +1,34 @@
+package noul.oe.arch
+
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class ArchTest {
+    // 분석할 기준 패키지 루트
+    private val basePackage = "noul.oe.domain"
+
+    // 지정한 패키지 이하의 class 파일 로드
+    private val classes = ClassFileImporter().importPackages(basePackage)
+
+    @Test
+    @DisplayName("post 패키지는 user, comment 패키지에 의존하면 안된다")
+    fun test1() {
+        noClasses()
+            .that().resideInAPackage("$basePackage.post..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("$basePackage.user..", "$basePackage.comment..")
+            .check(classes)
+    }
+
+    @Test
+    @DisplayName("comment 패키지는 user, post 패키지에 의존하면 안된다")
+    fun test2() {
+        noClasses()
+            .that().resideInAPackage("$basePackage.comment..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("$basePackage.user..", "$basePackage.post..")
+            .check(classes)
+    }
+}


### PR DESCRIPTION
1. archunit dependency 추가 및 arch 테스트 작성
  - post, comment 모듈이 각 도메인 모듈을 의존하는지 확인

2. 도메인 별 InfoProvider 도입으로 모듈 간 의존성 제거